### PR TITLE
Added new dev app for dev endpoint

### DIFF
--- a/manifest.yml
+++ b/manifest.yml
@@ -1,5 +1,16 @@
 # This manifest deploys a Python Flask application with a Redis database
 applications:
+- name: nyu-wishlist-service-s18-dev
+  memory: 64M
+  instances: 2
+  #random-route: true
+  host: nyu-wishlist-service-s18-dev
+  domain: mybluemix.net
+  path: .
+  disk_quota: 512M
+  buildpack: python_buildpack
+  services:
+  - ElephantSQL
 - name: nyu-wishlist-service-s18
   memory: 64M
   instances: 2
@@ -10,4 +21,4 @@ applications:
   disk_quota: 512M
   buildpack: python_buildpack
   services:
-  - ElephantSQL 
+  - ElephantSQL


### PR DESCRIPTION
I believe the manifest file needs this to know which endpoints to deploy to. I changed the app names in bluemix to explicitly use the app names in manifest.yml, so the stage only deploys at that URL.